### PR TITLE
opam-related convenience & explanation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ provide a label that will search for a type matching a given
 pattern. In the following example, we can return the desired argument
 by referring to its type:
 
-    Lemma example: 
-      forall t e1 e2 , 
+    Lemma example:
+      forall t e1 e2 ,
         is_foo e1 t -> is_foo e2 t -> is_foo e1 t.
     Proof.
       intros.
@@ -38,8 +38,8 @@ by referring to its type:
 In fact, our pattern could have been more general since there is no
 other assumption matching `is_foo e1`:
 
-    Lemma example_patt: 
-      forall t e1 e2 , 
+    Lemma example_patt:
+      forall t e1 e2 ,
         is_foo e1 t -> is_foo e2 t -> is_foo e1 t.
     Proof.
       intros.
@@ -49,8 +49,8 @@ other assumption matching `is_foo e1`:
 Nonetheless, if we are too general and do not mention `e1`, the
 label is ambiguous and will be rejected:
 
-    Lemma example_too_general: 
-      forall t e1 e2 , 
+    Lemma example_too_general:
+      forall t e1 e2 ,
         is_foo e1 t -> is_foo e2 t -> is_foo e1 t.
     Proof.
       intros.
@@ -60,7 +60,7 @@ label is ambiguous and will be rejected:
 Finally, if we want to match the end of a type telescope, we must
 explicitly request it through a double label:
 
-    Lemma example_concl: 
+    Lemma example_concl:
       (forall e t, is_foo e t) -> forall e t, is_foo e t.
     Proof.
       intros.

--- a/README.md
+++ b/README.md
@@ -69,6 +69,19 @@ explicitly request it through a double label:
 
 ## Installation
 
+### Using `opam`
+
+Install the library (available in
+the [Coq opam repository](http://coq.io/opam/)):
+
+    opam install coq-label
+
+Then, to load the library in a Coq script:
+
+    Require Import Label.Plugin.
+
+### Manual setup
+
 Assuming that you have a working installation of Coq.trunk, do `make`.
 This will consecutively build the plugin and the supporting theories.
 

--- a/opam
+++ b/opam
@@ -1,0 +1,17 @@
+opam-version: "1.2"
+maintainer: "pierre-evariste.dagand@lip6.fr"
+homepage: "https://github.com/pedagand/coq-label"
+dev-repo: "https://github.com/pedagand/coq-label.git"
+bug-reports: "https://github.com/pedagand/coq-label/issues"
+authors: ["Pierre-Évariste Dagand" "Théo Zimmermann" "Pierre-Marie Pédrot"]
+license: "MIT"
+build: [
+  [make "-j%{jobs}%"]
+]
+install: [
+  [make "install"]
+]
+remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Label"]
+depends: [
+  "coq" {>= "8.7"}
+]


### PR DESCRIPTION
- add an `opam` file to the root of the repo; this enables pinning the development repo using `opam pin`
- add a section to the README explaining how to load install & load the library when using opam