### PR TITLE
Compatibility with Coq 8.8

### DIFF
--- a/opam
+++ b/opam
@@ -13,5 +13,5 @@ install: [
 ]
 remove: ["rm" "-R" "%{lib}%/coq/user-contrib/Label"]
 depends: [
-  "coq" {>= "8.7"}
+  "coq" {>= "8.8"}
 ]

--- a/src/label_plugin.ml4
+++ b/src/label_plugin.ml4
@@ -22,7 +22,7 @@ let label ?(concl=false) patt =
       Printf.ifprintf stderr "Checking pattern %s against conclusion %s\n"
                       (Pp.string_of_ppcmds (Printer.pr_constr_pattern_env env sigma patt))
                       (Pp.string_of_ppcmds (Printer.pr_econstr_env env sigma typ));
-      Constr_matching.is_matching_conv env sigma patt typ
+      Constr_matching.is_matching env sigma patt typ
     in
     let wit = List.find_all is_matching_patt hyps in
     match wit with
@@ -48,7 +48,7 @@ let glob_label_patt ist pat =
                  ; ltac_bound = Names.Id.Set.empty
                  ; ltac_extra = Genintern.Store.empty }
   in
-  snd (intern_constr_pattern ~ltacvars:ltacsign ist.genv pat)
+  snd (intern_constr_pattern ~ltacvars:ltacsign ist.genv (Evd.from_env ist.genv) pat)
 let subst_label_patt subst pat = Patternops.subst_pattern subst pat
 
 ARGUMENT EXTEND label_patt


### PR DESCRIPTION
This PR makes the plugin compatible with Coq 8.8 (thanks to the help of @ppedrot on gitter). 

The change related to `intern_constr_pattern` is _not_ backwards compatible, so I updated the constraint version in the opam file. I guess this is fine since the previous version (compatible with coq 8.7) will still be available in opam? Otherwise we could do conditional compilation using cppo... I'm not sure it is worth bothering.

If this is merged then of course it would be nice to have a new opam release :).

Fixes #7 